### PR TITLE
Fixes

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -136,8 +136,8 @@ WriteMakefile($abmm->mm_args(
     CONFIGURE_REQUIRES => {
         # DEV NOTE, CORRELATION #ap001: must install IO::Socket::SSL & Alien::Build from Makefile.PL (which becomes META.json, for CPAN) & .travis.yml & appveyor.yml 
         'IO::Socket::SSL'       => '2.043',
-        'Alien::Build'          => '0.52',  # provides Alien::Build::MM
-        'Alien::Build::MM'      => 0,
+        'Alien::Build'          => '0.53',  # provides Alien::Build::MM
+        'Alien::Build::MM'      => '0.53',
         'Alien::PCRE2'          => '0.006',  # DEV NOTE, CORRELATION #aj00: NEED ANSWER, DOES THIS WORK VIA cpanm???
         'File::Find::Rule'      => '0.34',  # used to find config.status file in t/02_make_check.t
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -137,6 +137,7 @@ WriteMakefile($abmm->mm_args(
         # DEV NOTE, CORRELATION #ap001: must install IO::Socket::SSL & Alien::Build from Makefile.PL (which becomes META.json, for CPAN) & .travis.yml & appveyor.yml 
         'IO::Socket::SSL'       => '2.043',
         'Alien::Build'          => '0.52',  # provides Alien::Build::MM
+        'Alien::Build::MM'      => 0,
         'Alien::PCRE2'          => '0.006',  # DEV NOTE, CORRELATION #aj00: NEED ANSWER, DOES THIS WORK VIA cpanm???
         'File::Find::Rule'      => '0.34',  # used to find config.status file in t/02_make_check.t
     },

--- a/alienfile
+++ b/alienfile
@@ -2,19 +2,13 @@ use alienfile;
 
 our $VERSION = 0.007_000;
 
-# DEV NOTE, CORRELATION #aj00: NEED ANSWER, DOES THIS WORK AT ALL???
-configure {
-    requires 'Alien::PCRE2' => '0.006';
-};
-
-use Alien::PCRE2;
-my $pcre2_dist_dir = Alien::PCRE2->dist_dir();
-print {*STDERR} "\n\n", q{<<< DEBUG >>> in alienfile, have $pcre2_dist_dir = '}, $pcre2_dist_dir, q{'}, "\n\n";
- 
-plugin 'PkgConfig' => 'libjpcre2';
+plugin 'Probe::CBuilder' => (
+  aliens => [ 'Alien::PCRE2' ],
+  program => "#include <jpcre2.hpp>\nint main() { return 0; }\n",
+  lang => 'C++',
+);
  
 share {
-    requires 'Alien::PCRE2' => '0.006';  # DEV NOTE, CORRELATION #aj00: NEED ANSWER, DOES THIS WORK AT ALL???
     plugin Download => (
         url => 'https://wbraswell.github.io/jpcre2-mirror/',
         filter => qr/^jpcre2-.*\.tar\.gz$/,
@@ -22,8 +16,13 @@ share {
     );
     plugin Extract => 'tar.gz';
     plugin 'Build::Autoconf' => ();
+    plugin 'Build::SearchDep' => (
+        aliens => [ 'Alien::PCRE2' ],
+        public_I => 1,
+        public_l => 1,
+    );
     build [
-        '%{configure}' . ' --enable-cpp11 LDFLAGS=-L' . $pcre2_dist_dir . '/lib CPPFLAGS=-I' . $pcre2_dist_dir . '/include --enable-test', 
+        '%{configure}' . ' --enable-cpp11 --enable-test', 
         '%{gmake}',
         '%{gmake} install',
     ];


### PR DESCRIPTION
This addresses a few issues I had in trying to install this dist.

 1. Alien::Build::MM is currently bundled with Alien-Build, but it may not always be, so you want to explicitly require it
 2. jpcre2 doesn't provide a .pc file, so the PkgConfig plugin doesn't do anything, in fact it will fail during the gather stage since the share build won't provide a .pc file for it to find.  Instead use Probe::CBuilder plugin.  This plugin added support for C++ in 0.53, so you will need that.
 3. Instead of calculating your own LDFLAGS and CPPFLAGS, use the Build::SearchDep plugin which will also add them to the runtime cflags and libs for Alien::JPCRE2 needed by modules that depend on this one.

I am not sure why you are trying to install Alien::PCRE2 from Makefile.PL, this should be the responsibility of which ever cpan client that is used.  The configure requires are set correctly.