### PR TITLE
Upgrade to Strawberry Perl v5.26.0.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,6 @@ install:
 
     curl -V
 
-    #curl -o perl.msi http://strawberryperl.com/download/5.24.0.1/strawberry-perl-5.24.0.1-32bit.msi
     curl -o perl.msi http://strawberryperl.com/download/5.26.0.1/strawberry-perl-5.26.0.1-32bit.msi
 
     msiexec /i perl.msi /quiet /qn /norestart

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,8 @@ install:
 
     curl -V
 
-    curl -o perl.msi http://strawberryperl.com/download/5.24.0.1/strawberry-perl-5.24.0.1-32bit.msi
+    #curl -o perl.msi http://strawberryperl.com/download/5.24.0.1/strawberry-perl-5.24.0.1-32bit.msi
+    curl -o perl.msi http://strawberryperl.com/download/5.26.0.1/strawberry-perl-5.26.0.1-32bit.msi
 
     msiexec /i perl.msi /quiet /qn /norestart
 
@@ -74,11 +75,11 @@ install:
 
     perl Makefile.PL
 
-    dmake
+    gmake
 
-    dmake test
+    gmake test
 
-    dmake install
+    gmake install
 
     perl -le "use Alien::JPCRE2; use Env qw(@PATH); unshift @PATH, Alien::JPCRE2->bin_dir(); print q{have Alien::JPCRE2->dist_dir() = }, Alien::JPCRE2->dist_dir(), \"\n\";"
 


### PR DESCRIPTION
Breaks the ground in sense of it is really needed the make libjpcre2 compiling. Previous versions of Strawberry Perl haven't provided the needed version of g++ ('>=5.x.x'). And 'gmake' is the one and only maker now (using 'dmake' will produce an error message from now on).